### PR TITLE
fix: aws provider 6.0 depricated kibana_endpoint in favor or dashboard_endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   aws_service_domain_endpoint        = coalesce(join("", aws_elasticsearch_domain.default[*].endpoint), join("", aws_opensearch_domain.default[*].endpoint))
   aws_service_domain_id              = coalesce(join("", aws_elasticsearch_domain.default[*].domain_id), join("", aws_opensearch_domain.default[*].domain_id))
   aws_service_domain_name            = coalesce(join("", aws_elasticsearch_domain.default[*].domain_name), join("", aws_opensearch_domain.default[*].domain_name))
-  aws_service_domain_kibana_endpoint = coalesce(join("", aws_elasticsearch_domain.default[*].kibana_endpoint), join("", aws_opensearch_domain.default[*].kibana_endpoint))
+  aws_service_domain_kibana_endpoint = coalesce(join("", aws_elasticsearch_domain.default[*].dashboard_endpoint), join("", aws_opensearch_domain.default[*].dashboard_endpoint))
 }
 
 module "user_label" {


### PR DESCRIPTION
…

## what
kibana_endpoint - (Deprecated) Domain-specific endpoint for kibana without https scheme. Use the dashboard_endpoint
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
